### PR TITLE
Fixing issue #MM26. Read big file size. 

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -12,15 +12,17 @@ import (
 )
 
 var (
-	dir   = flag.String("dir", "/usr/local/nagios/etc/", "Nagios configuration files directory")
-	url   = flag.String("url", "", "Mattermost Server address")
-	token = flag.String("token", "", "Nagios plugin token")
+	dir    = flag.String("dir", "/usr/local/nagios/etc/", "Nagios configuration files directory")
+	url    = flag.String("url", "", "Mattermost Server address")
+	token  = flag.String("token", "", "Nagios plugin token")
+	tmpdir = flag.String("tmpdir", "$HOME/temp/watcher", "Temporary Folder to put big File")
 )
 
 func main() {
 	flag.Parse()
 
 	baseDir := *dir
+	tempDir := *tmpdir
 
 	if !filepath.IsAbs(baseDir) {
 		log.Fatal("dir argument must be an absolute path, like /usr/local/nagios/etc/")
@@ -33,7 +35,7 @@ func main() {
 		log.Fatalf("GetAllInDirectory: %v", err)
 	}
 
-	differential, err := watcher.NewDifferential(ignoredExtensions, files, http.DefaultClient, *url, *token)
+	differential, err := watcher.NewDifferential(ignoredExtensions, files, http.DefaultClient, *url, *token, tempDir)
 	if err != nil {
 		log.Fatalf("NewDifferential: %v", err)
 	}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/md5" //nolint:gosec
 	"encoding/json"
@@ -26,6 +27,12 @@ func getIgnoredExtensions(extensions []string) map[string]struct{} {
 
 	return lookup
 }
+
+var (
+	MaxFileSize        int64 = 100 * 1024 * 1024
+	MaxReadSize        int64 = 5 * 1024 * 1024
+	TemporaryDirectory       = os.Getenv("HOME") + "/temp/watcher"
+)
 
 // GetAllInDirectory recursively returns all paths to files and directories in
 // dir (excluding files with ignored extensions). It returns nil, nil, <err> on
@@ -174,33 +181,55 @@ func (d Differential) WatchFn(path string) error {
 		return nil
 	}
 
-	// This is to allow for changes to propagate on the filesystem. If the file
-	// is large, the write won't be atomic. It will happen in, for example, 4096
-	// bytes chunks. 1 ms should be enough.
-	time.Sleep(time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
-	contents, err := ioutil.ReadFile(path)
+	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("ioutil.ReadFile: %w", err)
+		return fmt.Errorf("error read file status %w", err)
 	}
 
-	checksum := md5.Sum(contents) //nolint:gosec
+	if info.Size() >= MaxFileSize {
+		log.Printf("File equal or higher than %v MB", MaxFileSize/1024/1024)
 
-	if checksum == d.previousChecksum[path] {
-		return nil
+		srcFile, ok := d.previousContents[path]
+		if ok {
+			err := d.readFileAndFindDiff(path, string(srcFile))
+			return err
+		} else {
+			log.Println("New File appeared")
+			fileTemp := TemporaryDirectory + "/" + info.Name()
+			err = CopyFile(path, fileTemp)
+			if err != nil {
+				return fmt.Errorf("error copy file  %w", err)
+			}
+
+			err = d.readFileAndFindDiff(path, string(srcFile))
+			return err
+		}
+
+	} else {
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("ioutil.ReadFile: %w", err)
+		}
+
+		checksum := md5.Sum(contents) //nolint:gosec
+
+		if checksum == d.previousChecksum[path] {
+			return nil
+		}
+
+		diff := cmp.Diff(string(d.previousContents[path]), string(contents))
+
+		if err := d.sendDiff(path, diff); err != nil {
+			return fmt.Errorf("d.sendDiff: %w", err)
+		}
+
+		log.Printf("Sent the diff (size = %d)", len(diff))
+
+		d.previousChecksum[path] = checksum
+		d.previousContents[path] = contents
 	}
-
-	diff := cmp.Diff(string(d.previousContents[path]), string(contents))
-
-	if err := d.sendDiff(path, diff); err != nil {
-		return fmt.Errorf("d.sendDiff: %w", err)
-	}
-
-	log.Printf("Sent the diff (size = %d)", len(diff))
-
-	d.previousChecksum[path] = checksum
-	d.previousContents[path] = contents
-
 	return nil
 }
 
@@ -208,18 +237,48 @@ func (d Differential) WatchFn(path string) error {
 func NewDifferential(
 	ignoredExtensions, initialFilePaths []string,
 	httpClient *http.Client,
-	url, token string) (Differential, error) {
+	url, token, tempDir string) (Differential, error) {
 	previousChecksum := make(map[string][16]byte)
 	previousContents := make(map[string][]byte)
 
+	if tempDir != "" {
+		TemporaryDirectory = tempDir
+	}
 	for _, p := range initialFilePaths {
-		b, err := ioutil.ReadFile(p)
+		info, err := os.Stat(p)
 		if err != nil {
-			return Differential{}, fmt.Errorf("ioutil.ReadFile: %w", err)
+			return Differential{}, fmt.Errorf("error read file status %w", err)
 		}
 
-		previousChecksum[p] = md5.Sum(b) //nolint:gosec
-		previousContents[p] = b
+		if info.Size() >= MaxFileSize {
+			log.Printf("File equal or higher than %v MB", MaxFileSize/1024/1024)
+
+			_, err = os.Stat(TemporaryDirectory)
+			if os.IsNotExist(err) {
+				err := os.MkdirAll(TemporaryDirectory, 0777)
+				if err != nil {
+					return Differential{}, fmt.Errorf("error create temporary folder %w", err)
+				}
+			}
+
+			fileTemp := TemporaryDirectory + "/" + info.Name()
+			err = CopyFile(p, fileTemp)
+			if err != nil {
+				return Differential{}, fmt.Errorf("error copy file  %w", err)
+			}
+
+			// Only write temporary folder directory
+			previousContents[p] = []byte(fileTemp)
+
+		} else {
+			b, err := ioutil.ReadFile(p)
+			if err != nil {
+				return Differential{}, fmt.Errorf("ioutil.ReadFile: %w", err)
+			}
+
+			previousChecksum[p] = md5.Sum(b) //nolint:gosec
+			previousContents[p] = b
+		}
 	}
 
 	return Differential{
@@ -230,4 +289,121 @@ func NewDifferential(
 		url:               url,
 		token:             token,
 	}, nil
+}
+
+// CopyFile copies a file from src to dst. If src and dst files exist, and are
+// the same, then return success. If that fail, copy the file contents from src to dst.
+func CopyFile(src, dst string) (err error) {
+	sfi, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	if !sfi.Mode().IsRegular() {
+		// cannot copy non-regular files (e.g., directories,
+		// symlinks, devices, etc.)
+		return fmt.Errorf("CopyFile: non-regular source file %s (%q)", sfi.Name(), sfi.Mode().String())
+	}
+	dfi, err := os.Stat(dst)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return
+		}
+	} else {
+		if !(dfi.Mode().IsRegular()) {
+			return fmt.Errorf("CopyFile: non-regular destination file %s (%q)", dfi.Name(), dfi.Mode().String())
+		}
+		if os.SameFile(sfi, dfi) {
+			return
+		}
+	}
+
+	err = copyFileContents(src, dst)
+	return
+}
+
+// copyFileContents copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file.
+func copyFileContents(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	if _, err = io.Copy(out, in); err != nil {
+		return
+	}
+	err = out.Sync()
+	return
+}
+
+func (d Differential) readFileAndFindDiff(path, srcFile string) (err error) {
+
+	f1, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("error openning watched file : %w", err)
+	}
+	f2, err := os.Open(srcFile)
+	if err != nil {
+		return fmt.Errorf("error openning temp file: %w", err)
+	}
+	defer f1.Close()
+	defer f2.Close()
+
+	r1 := bufio.NewReader(f1)
+	r2 := bufio.NewReader(f2)
+
+	eof1 := false
+	eof2 := false
+
+	for {
+		buf1 := make([]byte, MaxReadSize)
+		buf2 := make([]byte, MaxReadSize)
+		// read first file
+		n, err := r1.Read(buf1)
+		if err == io.EOF {
+			eof1 = true
+		} else if err != nil {
+			return fmt.Errorf("error read chunkz watched file: %w", err)
+		}
+		content1 := buf1[:n]
+
+		// read second file
+		n, err = r2.Read(buf2)
+		if err == io.EOF {
+			eof2 = true
+		} else if err != nil {
+			return fmt.Errorf("error read chunkz watched file: %w", err)
+		}
+		content2 := buf2[:n]
+
+		if eof1 && eof2 {
+			break
+		}
+
+		checksum1 := md5.Sum(content1) //nolint:gosec
+		checksum2 := md5.Sum(content2) //nolint:gosec
+
+		if checksum1 == checksum2 {
+			continue
+		}
+
+		diff := cmp.Diff(string(content2), string(content1))
+
+		if err := d.sendDiff(path, diff); err != nil {
+			return fmt.Errorf("d.sendDiff: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/watcher/watcher_hasbi_test.go
+++ b/internal/watcher/watcher_hasbi_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestWatchFn(t *testing.T) {
 
-	// MaxFileSize = 17*10 ^ 3
-	// MaxReadSize = 5 * 1024
+	MaxFileSize = 20 * 1024
+	MaxReadSize = 5 * 1024
 
 	ignoredExtension := []string{".swp"}
 	// path := "/home/hasbi/file_watcher/100MB.bin"
@@ -19,7 +19,7 @@ func TestWatchFn(t *testing.T) {
 
 	files := []string{path}
 
-	differential, err := NewDifferential(ignoredExtension, files, http.DefaultClient, "http://localhost:8065", "2137", "/home/hasbi/")
+	differential, err := NewDifferential(ignoredExtension, files, http.DefaultClient, "http://localhost:8065", "2137", TemporaryDirectory)
 	if err != nil {
 		fmt.Printf("%+v \n", err)
 		return

--- a/internal/watcher/watcher_hasbi_test.go
+++ b/internal/watcher/watcher_hasbi_test.go
@@ -1,0 +1,49 @@
+package watcher
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+	"testing"
+)
+
+func TestWatchFn(t *testing.T) {
+
+	// MaxFileSize = 17*10 ^ 3
+	// MaxReadSize = 5 * 1024
+
+	ignoredExtension := []string{".swp"}
+	// path := "/home/hasbi/file_watcher/100MB.bin"
+	path := "/home/hasbi/file_watcher/BTOP.txt"
+	// path := "/home/hasbi/file_watcher/file.txt"
+
+	files := []string{path}
+
+	differential, err := NewDifferential(ignoredExtension, files, http.DefaultClient, "http://localhost:8065", "2137", "/home/hasbi/")
+	if err != nil {
+		fmt.Printf("%+v \n", err)
+		return
+	}
+
+	err = differential.WatchFn(path)
+	if err != nil {
+		fmt.Printf("%+v \n", err)
+		return
+	}
+
+}
+
+func CheckMem() {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	fmt.Printf("\n")
+	fmt.Printf("Alloc: %d MB, TotalAlloc: %d MB, Sys: %d MB\n",
+		ms.Alloc/1024/1024, ms.TotalAlloc/1024/1024, ms.Sys/1024/1024)
+	fmt.Printf("Mallocs: %d, Frees: %d\n",
+		ms.Mallocs, ms.Frees)
+	fmt.Printf("HeapAlloc: %d MB, HeapSys: %d MB, HeapIdle: %d MB\n",
+		ms.HeapAlloc/1024/1024, ms.HeapSys/1024/1024, ms.HeapIdle/1024/1024)
+	fmt.Printf("HeapObjects: %d\n", ms.HeapObjects)
+	fmt.Printf("\n")
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -149,7 +149,7 @@ func TestNewDifferential(t *testing.T) {
 			token:             "",
 		}
 
-		actual, err := NewDifferential(nil, nil, nil, "", "")
+		actual, err := NewDifferential(nil, nil, nil, "", "", "")
 		if err != nil {
 			t.Fatalf("NewDifferential: %v", err)
 		}
@@ -205,7 +205,7 @@ func TestNewDifferential(t *testing.T) {
 			t.Fatalf("GetAllInDirectory: %v", err)
 		}
 
-		actual, err := NewDifferential([]string{".swp"}, files, http.DefaultClient, "dummy", "2137")
+		actual, err := NewDifferential([]string{".swp"}, files, http.DefaultClient, "dummy", "2137", "")
 		if err != nil {
 			t.Fatalf("NewDifferential: %v", err)
 		}


### PR DESCRIPTION
#### Summary :

1. The Pull Request prevents the watcher from reading files of 100MB and above because the system might run out of memory. Instead of reading files, the watcher puts large files into customizable temporary folders. If the file is lower than 100 MB, the watcher reads as usual using 'ioutil'. 

2. For large files, watcher reads using a buffer ('bufio') of 5 MB per loop. Each loop will find the difference and send the difference. 

#### Ticket Link : https://github.com/mattermost/mattermost-plugin-nagios/issues/26